### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.4
+MAINTAINER laiwei laiwei.ustc@gmail.com
+
+ADD . /go/src/github.com/open-falcon/agent
+WORKDIR /go/src/github.com/open-falcon/agent
+RUN go get
+RUN go build
+
+EXPOSE 1988
+
+CMD ./control start && tail -F var/app.log


### PR DESCRIPTION
Now we can start agent without installing golang or other dependencies :smiley: 

Usage: `sudo docker run -d -p 1988:1988 open-falcon/agent`
