### PR TITLE
让agent插件分发支持更多种方式

### DIFF
--- a/cfg.example.json
+++ b/cfg.example.json
@@ -4,8 +4,9 @@
     "ip": "",
     "plugin": {
         "enabled": false,
-        "dir": "./plugin",
-        "git": "https://coding.net/ulricqin/plugin.git",
+        "protocol": "git"
+        "dir": "./plugins",
+        "uri": "https://coding.net/ulricqin/plugin.git",
         "logs": "./logs"
     },
     "heartbeat": {

--- a/cron/httpDownloadPlugins.go
+++ b/cron/httpDownloadPlugins.go
@@ -115,7 +115,7 @@ func ValidateFileMd5(md5file string) bool {
 
 func TarPackage(plugin_name string, dstdir string) bool {
 	tgzfile := filepath.Join("./tmp", plugin_name+".tar.gz")
-	srcplugin := filepath.Join("./plugins", plugin_name)
+	srcplugin := filepath.Join(dstdir, plugin_name)
 	RmDir(srcplugin)
 	shell := "tar -zxf " + tgzfile + " -C " + dstdir
 	err := ExeCmd(shell)
@@ -166,8 +166,9 @@ func CheckPluginUpdate(plugins []string, cycle time.Duration) {
 			continue
 		}
 		//decompress package
-		file.InsureDir("./plugins")
-		if ok := TarPackage(plugin, "./plugins"); !ok {
+		plugin_dir := g.Config().Plugin.Dir
+		file.InsureDir(plugin_dir)
+		if ok := TarPackage(plugin, plugin_dir); !ok {
 			continue
 		}
 		//update tmp md5file to real md5file

--- a/cron/httpDownloadPlugins.go
+++ b/cron/httpDownloadPlugins.go
@@ -1,0 +1,179 @@
+package cron
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/open-falcon/agent/g"
+	"github.com/toolkits/file"
+	"github.com/toolkits/sys"
+)
+
+func WgetRun(filename string, dst string, Timeout time.Duration) error {
+	timeout := Timeout*1000 - 500
+	debug := g.Config().Debug
+	duri := g.Config().Plugin.Uri + "/" + filename
+	shell := "wget " + duri + " -O " + dst
+	if debug {
+		log.Println(shell, " running...")
+	}
+	cmd := exec.Command("/bin/bash", "-c", shell)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Start()
+
+	err, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(timeout)*time.Millisecond)
+
+	errStr := stderr.String()
+	file_prefix := strings.Split(filename, ".")[0]
+	if errStr != "" {
+		logFile := filepath.Join(g.Config().Plugin.LogDir, file_prefix+".stderr.log")
+		if _, err = file.WriteString(logFile, errStr); err != nil {
+			log.Printf("[ERROR] write log to %s fail, error: %s\n", logFile, err)
+		}
+	}
+
+	if isTimeout {
+		// has be killed
+		if err == nil && debug {
+			log.Println("[INFO] timeout and kill process", cmd, "successfully")
+		}
+
+		if err != nil {
+			log.Println("[ERROR] kill process", cmd, "occur error:", err)
+		}
+
+		return err
+	}
+
+	if err != nil {
+		log.Println("[ERROR] exec cmd:", cmd, "fail. error:", err)
+		return err
+	}
+	return err
+}
+
+func ExeCmd(shell string) error {
+	cmdobj := exec.Command("/bin/bash", "-c", shell)
+	err := cmdobj.Run()
+	if err != nil {
+		log.Println("[ERROR] cmd:", shell, "fail.error:", err)
+		return err
+	}
+	return err
+}
+
+func CheckMd5Update(filename string, Timeout time.Duration) bool {
+	file.InsureDir("./md5file")
+	file.InsureDir("./tmp")
+	dstfile := filepath.Join("./tmp", filename+".tmp")
+	if err := WgetRun(filename, dstfile, Timeout); err != nil {
+		return false
+	}
+	//get local md5 value
+	local_md5_path := filepath.Join("./md5file", filename)
+	if !file.IsExist(local_md5_path) {
+		return true
+	}
+	lbuff, err := ioutil.ReadFile(local_md5_path)
+	if err != nil {
+		log.Println("read file from file:", local_md5_path, "fail.error is ", err)
+		return true
+	}
+	local_md5 := string(strings.Trim(string(lbuff), "")[0:32])
+	//get remote md5 value
+	remote_md5_path := filepath.Join(dstfile)
+	rbuff, err := ioutil.ReadFile(remote_md5_path)
+	if err != nil {
+		log.Println("read file from file:", remote_md5_path, "fail.error is ", err)
+		return false
+	}
+	remote_md5 := string(strings.Trim(string(rbuff), "")[0:32])
+	if local_md5 != remote_md5 {
+		log.Println("md5 change with remote,update plugin.", filename)
+		return true
+	}
+	return false
+}
+
+func ValidateFileMd5(md5file string) bool {
+	shell := "cd ./tmp && md5sum -c " + md5file
+	err := ExeCmd(shell)
+	if err != nil {
+		log.Println("the md5 file validate failed:", md5file, "the error:", err)
+		return false
+	}
+	return true
+}
+
+func TarPackage(plugin_name string, dstdir string) bool {
+	tgzfile := filepath.Join("./tmp", plugin_name+".tar.gz")
+	srcplugin := filepath.Join("./plugins", plugin_name)
+	RmDir(srcplugin)
+	shell := "tar -zxf " + tgzfile + " -C " + dstdir
+	err := ExeCmd(shell)
+	if err != nil {
+		log.Println("extract file ", tgzfile, "faild. error:", err)
+		return false
+	}
+	return true
+}
+
+func CpFile(srcdir string, dstdir string) bool {
+	shell := "cp " + srcdir + " " + dstdir
+	err := ExeCmd(shell)
+	if err != nil {
+		log.Println("cp src dir", srcdir, "to dst dir", dstdir, "failed. error:", err)
+		return false
+	}
+	return true
+}
+
+func RmDir(dir string) bool {
+	if file.IsExist(dir) {
+		shell := "rm -rf " + dir
+		err := ExeCmd(shell)
+		if err != nil {
+			log.Println("rm dir or file ", dir, "faild. error:", err)
+			return false
+		}
+		return true
+	}
+	return true
+}
+
+func CheckPluginUpdate(plugins []string, cycle time.Duration) {
+	for _, plugin := range plugins {
+		if ok := CheckMd5Update(plugin+".md5", 60); !ok {
+			log.Println("the plugin:", plugin, "has not updated.")
+			continue
+		}
+		log.Println("the plugin:", plugin, "has updated.")
+		//Plugin's md5 change with local,update plugin
+		pack_name := plugin + ".tar.gz"
+		dst_name := filepath.Join("./tmp", plugin+".tar.gz")
+		WgetRun(pack_name, dst_name, cycle)
+		if ok := ValidateFileMd5(plugin + ".md5.tmp"); !ok {
+			RmDir("./tmp/" + plugin + ".md5.tmp")
+			RmDir("./tmp/" + plugin + ".tar.gz")
+			continue
+		}
+		//decompress package
+		file.InsureDir("./plugins")
+		if ok := TarPackage(plugin, "./plugins"); !ok {
+			continue
+		}
+		//update tmp md5file to real md5file
+		if ok := CpFile("./tmp/"+plugin+".md5.tmp", "./md5file/"+plugin+".md5"); !ok {
+			continue
+		}
+	}
+	return
+}

--- a/cron/plugin.go
+++ b/cron/plugin.go
@@ -60,7 +60,10 @@ func syncMinePlugins() {
 
 		pluginDirs = resp.Plugins
 		timestamp = resp.Timestamp
-
+		//pluginDirs = append(pluginDirs, "lain")
+		//log.Println("**************************come in dir***********************", pluginDirs)
+		//add func to download the plugins with update
+		CheckPluginUpdate(pluginDirs, duration)
 		if g.Config().Debug {
 			log.Println(&resp)
 		}

--- a/cron/plugin.go
+++ b/cron/plugin.go
@@ -33,7 +33,8 @@ func syncMinePlugins() {
 	)
 
 	duration := time.Duration(g.Config().Heartbeat.Interval) * time.Second
-
+	protocol := g.Config().Plugin.Protocol
+	log.Println("the plugin's update protocol is:", protocol)
 	for {
 	REST:
 		time.Sleep(duration)
@@ -60,10 +61,6 @@ func syncMinePlugins() {
 
 		pluginDirs = resp.Plugins
 		timestamp = resp.Timestamp
-		//pluginDirs = append(pluginDirs, "lain")
-		//log.Println("**************************come in dir***********************", pluginDirs)
-		//add func to download the plugins with update
-		CheckPluginUpdate(pluginDirs, duration)
 		if g.Config().Debug {
 			log.Println(&resp)
 		}
@@ -71,7 +68,10 @@ func syncMinePlugins() {
 		if len(pluginDirs) == 0 {
 			plugins.ClearAllPlugins()
 		}
-
+		//download the plugins that has updated with http
+		if protocol == "http" {
+			CheckPluginUpdate(pluginDirs, duration)
+		}
 		desiredAll := make(map[string]*plugins.Plugin)
 
 		for _, p := range pluginDirs {

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -9,10 +9,11 @@ import (
 )
 
 type PluginConfig struct {
-	Enabled bool   `json:"enabled"`
-	Dir     string `json:"dir"`
-	Git     string `json:"git"`
-	LogDir  string `json:"logs"`
+	Enabled  bool   `json:"enabled"`
+	Dir      string `json:"dir"`
+	Protocol string `json:"protocol"`
+	Uri      string `json:"uri"`
+	LogDir   string `json:"logs"`
 }
 
 type HeartbeatConfig struct {

--- a/http/plugin.go
+++ b/http/plugin.go
@@ -15,7 +15,12 @@ func configPluginRoutes() {
 			w.Write([]byte("plugin not enabled"))
 			return
 		}
-
+		//if the protocol is not git，return directly
+		protocol := g.Config().Plugin.Protocol
+		if protocol != "git" {
+			w.Write([]byte("the protocol is not git so can't update with http api."))
+			return
+		}
 		dir := g.Config().Plugin.Dir
 		parentDir := file.Dir(dir)
 		file.InsureDir(parentDir)
@@ -31,7 +36,7 @@ func configPluginRoutes() {
 			}
 		} else {
 			// git clone
-			cmd := exec.Command("git", "clone", g.Config().Plugin.Git, file.Basename(dir))
+			cmd := exec.Command("git", "clone", g.Config().Plugin.Uri, file.Basename(dir))
 			cmd.Dir = parentDir
 			err := cmd.Run()
 			if err != nil {


### PR DESCRIPTION
     加了一个支持http分发插件的逻辑，使用与hbs交互的时间间隔定期去探测插件是否有更新，如果有更新则将新的插件通过http下载到本地.
1.插件的打包规则：
   - 如果插件所在目录为lain，下面放了具体的采集脚本，那么需要打包成lain.tar.gz的包，同时调用md5sum -c lain.tar.gz > lain.md5 生成包的md5文件.

2.探测方法：
   - 探测的时候通过下载远端md5文件和本地插件上一个版本的md5文件值对比，如md5值变化则更新本地插件.

3.场景
   - 很多情况下用不了git...http是方式更廉价一些，随便搭一个nginx下载server即可，同时被动触发的方式不是太方便，这个探测的代价应该还是可以接受.