### PR TITLE
解决不支持部分aws机器的磁盘名称问题

### DIFF
--- a/funcs/diskstats.go
+++ b/funcs/diskstats.go
@@ -210,6 +210,6 @@ func IOStatsForPage() (L [][]string) {
 
 func ShouldHandleDevice(device string) bool {
 	normal := len(device) == 3 && (strings.HasPrefix(device, "sd") || strings.HasPrefix(device, "vd"))
-	aws := len(device) == 4 && strings.HasPrefix(device, "xvd")
+	aws := len(device) >= 4 && strings.HasPrefix(device, "xvd")
 	return normal || aws
 }


### PR DESCRIPTION
部分aws机器的磁盘名称为xvda1  而不是xvda
为了支持这部分机器磁盘，增加的兼容