### PR TITLE
agent的http dashboard页面中的URL绝对路径换成相对路径。

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1344,7 +1344,7 @@ overflow: hidden;
 padding: 20px 0 40px;
 }
 footer .site-source {
-background: url("/img/code.png") no-repeat scroll 0 2px transparent;
+background: url("../img/code.png") no-repeat scroll 0 2px transparent;
 float: left;
 padding-left: 46px;
 }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -109,7 +109,7 @@ jQuery.extend(jQuery.fn.dataTableExt.oSort, {
 var dashboard = {};
 
 dashboard.getRam = function () {
-    $.get("./page/memory", function (data) {
+    $.get("page/memory", function (data) {
         if (data.msg == "success") {
             var ram_total = data.data[0];
             var ram_used = Math.round((data.data[1] / ram_total) * 100);
@@ -126,7 +126,7 @@ dashboard.getRam = function () {
 }
 
 dashboard.getDf = function () {
-    $.get("./page/df", function (data) {
+    $.get("page/df", function (data) {
         var table = $("#df_dashboard");
         var ex = document.getElementById("df_dashboard");
         if ($.fn.DataTable.fnIsDataTable(ex)) {
@@ -158,7 +158,7 @@ dashboard.getDf = function () {
 }
 
 dashboard.getCpu = function () {
-    $.get("./page/cpu/usage", function (data) {
+    $.get("page/cpu/usage", function (data) {
         if (data.msg != "success") {
             return
         }
@@ -193,7 +193,7 @@ dashboard.getCpu = function () {
 }
 
 dashboard.getDiskstats = function () {
-    $.get("./page/diskio", function (data) {
+    $.get("page/diskio", function (data) {
         var table = $("#diskstats_dashboard");
         var ex = document.getElementById("diskstats_dashboard");
         if ($.fn.DataTable.fnIsDataTable(ex)) {
@@ -226,18 +226,18 @@ dashboard.getDiskstats = function () {
 }
 
 dashboard.getOs = function () {
-    generate_os_data("./proc/kernel/version", "#os-info");
-    generate_os_data("./proc/kernel/hostname", "#os-hostname");
-    generate_os_data("./system/date", "#os-time");
-    generate_os_data("./page/system/uptime", "#os-uptime");
+    generate_os_data("proc/kernel/version", "#os-info");
+    generate_os_data("proc/kernel/hostname", "#os-hostname");
+    generate_os_data("system/date", "#os-time");
+    generate_os_data("page/system/uptime", "#os-uptime");
 
-    $.get("./version", function(d){
+    $.get("version", function(d){
         $("#agent-version").text(d);
     });
 }
 
 dashboard.getLoadAverage = function () {
-    $.get("./page/system/loadavg", function (d) {
+    $.get("page/system/loadavg", function (d) {
         if (d.msg != "success") {
             return
         }
@@ -248,7 +248,7 @@ dashboard.getLoadAverage = function () {
         $("#cpu-5min-per").text(d.data[1][1]);
         $("#cpu-15min-per").text(d.data[2][1]);
     }, "json");
-    generate_os_data("./proc/cpu/num", "#core-number");
+    generate_os_data("proc/cpu/num", "#core-number");
 }
 
 /**

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -109,7 +109,7 @@ jQuery.extend(jQuery.fn.dataTableExt.oSort, {
 var dashboard = {};
 
 dashboard.getRam = function () {
-    $.get("/page/memory", function (data) {
+    $.get("./page/memory", function (data) {
         if (data.msg == "success") {
             var ram_total = data.data[0];
             var ram_used = Math.round((data.data[1] / ram_total) * 100);
@@ -126,7 +126,7 @@ dashboard.getRam = function () {
 }
 
 dashboard.getDf = function () {
-    $.get("/page/df", function (data) {
+    $.get("./page/df", function (data) {
         var table = $("#df_dashboard");
         var ex = document.getElementById("df_dashboard");
         if ($.fn.DataTable.fnIsDataTable(ex)) {
@@ -158,7 +158,7 @@ dashboard.getDf = function () {
 }
 
 dashboard.getCpu = function () {
-    $.get("/page/cpu/usage", function (data) {
+    $.get("./page/cpu/usage", function (data) {
         if (data.msg != "success") {
             return
         }
@@ -193,7 +193,7 @@ dashboard.getCpu = function () {
 }
 
 dashboard.getDiskstats = function () {
-    $.get("/page/diskio", function (data) {
+    $.get("./page/diskio", function (data) {
         var table = $("#diskstats_dashboard");
         var ex = document.getElementById("diskstats_dashboard");
         if ($.fn.DataTable.fnIsDataTable(ex)) {
@@ -226,18 +226,18 @@ dashboard.getDiskstats = function () {
 }
 
 dashboard.getOs = function () {
-    generate_os_data("/proc/kernel/version", "#os-info");
-    generate_os_data("/proc/kernel/hostname", "#os-hostname");
-    generate_os_data("/system/date", "#os-time");
-    generate_os_data("/page/system/uptime", "#os-uptime");
+    generate_os_data("./proc/kernel/version", "#os-info");
+    generate_os_data("./proc/kernel/hostname", "#os-hostname");
+    generate_os_data("./system/date", "#os-time");
+    generate_os_data("./page/system/uptime", "#os-uptime");
 
-    $.get("/version", function(d){
+    $.get("./version", function(d){
         $("#agent-version").text(d);
     });
 }
 
 dashboard.getLoadAverage = function () {
-    $.get("/page/system/loadavg", function (d) {
+    $.get("./page/system/loadavg", function (d) {
         if (d.msg != "success") {
             return
         }
@@ -248,7 +248,7 @@ dashboard.getLoadAverage = function () {
         $("#cpu-5min-per").text(d.data[1][1]);
         $("#cpu-15min-per").text(d.data[2][1]);
     }, "json");
-    generate_os_data("/proc/cpu/num", "#core-number");
+    generate_os_data("./proc/cpu/num", "#core-number");
 }
 
 /**


### PR DESCRIPTION
agent的http dashboard页面中的URL绝对路径换成相对路径，这样可以支持类似于http://proxyhost/ip/port/
代理方式查看dashboard。agent只监听在内网IP，在http proxy加IP白名单限制访问。

目前在public/js/dashboard.js中的请求URL都是直接填的根路径，导致加http proxy时处理不方便。