### PR TITLE
fix crash while sending data to multi-transfer

### DIFF
--- a/g/const.go
+++ b/g/const.go
@@ -9,8 +9,9 @@ import (
 // 3.1.4: bugfix ignore configuration
 // 5.0.0: 支持通过配置控制是否开启/run接口；收集udp流量数据；du某个目录的大小
 // 5.1.0: 同步插件的时候不再使用checksum机制
+// 5.1.1: 修复往多个transfer发送数据的时候crash的问题
 const (
-	VERSION          = "5.1.0"
+	VERSION          = "5.1.1"
 	COLLECT_INTERVAL = time.Second
 	URL_CHECK_HEALTH = "url.check.health"
 	NET_PORT_LISTEN  = "net.port.listen"

--- a/g/transfer.go
+++ b/g/transfer.go
@@ -17,35 +17,28 @@ var (
 func SendMetrics(metrics []*model.MetricValue, resp *model.TransferResponse) {
 	rand.Seed(time.Now().UnixNano())
 	for _, i := range rand.Perm(len(Config().Transfer.Addrs)) {
-		TransferClientsLock.Lock()
-
 		addr := Config().Transfer.Addrs[i]
 		if _, ok := TransferClients[addr]; !ok {
 			initTransferClient(addr)
 		}
 		if updateMetrics(addr, metrics, resp) {
-			TransferClientsLock.Unlock()
 			break
 		}
-		closeTransferClient(addr)
-
-		TransferClientsLock.Unlock()
 	}
 }
 
 func initTransferClient(addr string) {
+	TransferClientsLock.Lock()
+	defer TransferClientsLock.Unlock()
 	TransferClients[addr] = &SingleConnRpcClient{
 		RpcServer: addr,
 		Timeout:   time.Duration(Config().Transfer.Timeout) * time.Millisecond,
 	}
 }
 
-func closeTransferClient(addr string) {
-	TransferClients[addr].close()
-	delete(TransferClients, addr)
-}
-
 func updateMetrics(addr string, metrics []*model.MetricValue, resp *model.TransferResponse) bool {
+	TransferClientsLock.RLock()
+	defer TransferClientsLock.RUnlock()
 	err := TransferClients[addr].Call("Transfer.Update", metrics, resp)
 	if err != nil {
 		log.Println("call Transfer.Update fail", addr, err)

--- a/g/transfer.go
+++ b/g/transfer.go
@@ -10,27 +10,30 @@ import (
 )
 
 var (
-	TransferLock    *sync.RWMutex                   = new(sync.RWMutex)
-	TransferClients map[string]*SingleConnRpcClient = map[string]*SingleConnRpcClient{}
+	TransferClientsLock *sync.RWMutex                   = new(sync.RWMutex)
+	TransferClients     map[string]*SingleConnRpcClient = map[string]*SingleConnRpcClient{}
 )
 
 func SendMetrics(metrics []*model.MetricValue, resp *model.TransferResponse) {
 	rand.Seed(time.Now().UnixNano())
 	for _, i := range rand.Perm(len(Config().Transfer.Addrs)) {
+		TransferClientsLock.Lock()
+
 		addr := Config().Transfer.Addrs[i]
 		if _, ok := TransferClients[addr]; !ok {
 			initTransferClient(addr)
 		}
 		if updateMetrics(addr, metrics, resp) {
+			TransferClientsLock.Unlock()
 			break
 		}
 		closeTransferClient(addr)
+
+		TransferClientsLock.Unlock()
 	}
 }
 
 func initTransferClient(addr string) {
-	TransferLock.Lock()
-	defer TransferLock.Unlock()
 	TransferClients[addr] = &SingleConnRpcClient{
 		RpcServer: addr,
 		Timeout:   time.Duration(Config().Transfer.Timeout) * time.Millisecond,
@@ -38,15 +41,11 @@ func initTransferClient(addr string) {
 }
 
 func closeTransferClient(addr string) {
-	TransferLock.Lock()
-	defer TransferLock.Unlock()
 	TransferClients[addr].close()
 	delete(TransferClients, addr)
 }
 
 func updateMetrics(addr string, metrics []*model.MetricValue, resp *model.TransferResponse) bool {
-	TransferLock.RLock()
-	defer TransferLock.RUnlock()
 	err := TransferClients[addr].Call("Transfer.Update", metrics, resp)
 	if err != nil {
 		log.Println("call Transfer.Update fail", addr, err)


### PR DESCRIPTION
`SingleConnRpcClient.close()` will close rpc client , there is no need to define `func closeTransferClient()` and this function will cause panic. @laiwei 