### PR TITLE
fix goroutine leaks problem when timeout really happens.

### DIFF
--- a/g/rpc.go
+++ b/g/rpc.go
@@ -61,7 +61,7 @@ func (this *SingleConnRpcClient) Call(method string, args interface{}, reply int
 	this.insureConn()
 
 	timeout := time.Duration(50 * time.Second)
-	done := make(chan error)
+	done := make(chan error, 1)
 
 	go func() {
 		err := this.rpcClient.Call(method, args, reply)


### PR DESCRIPTION
Ref  https://github.com/golang/go/wiki/Timeouts

Using channel to implement timeout, channel should have a buffer size of 1. Otherwise, the goroutine that has the send channel would never be destroyed. 