### PR TITLE
sort tags which are in string format

### DIFF
--- a/funcs/dfstat.go
+++ b/funcs/dfstat.go
@@ -29,6 +29,7 @@ func DeviceMetrics() (L []*model.MetricValue) {
 		diskTotal += du.BlocksAll
 		diskUsed += du.BlocksUsed
 
+		// these tags are not sorted by "key"
 		tags := fmt.Sprintf("mount=%s,fstype=%s", du.FsFile, du.FsVfstype)
 		L = append(L, GaugeValue("df.bytes.total", du.BlocksAll, tags))
 		L = append(L, GaugeValue("df.bytes.used", du.BlocksUsed, tags))


### PR DESCRIPTION
对字符串形式出现的tags字符串按照key排序，和后端各模块对tags的处理方式保持一致
