### PR TITLE
df指标只采集指定挂载点

### DIFF
--- a/cfg.example.json
+++ b/cfg.example.json
@@ -29,7 +29,8 @@
         "backdoor": false
     },
     "collector": {
-        "ifacePrefix": ["eth", "em"]
+        "ifacePrefix": ["eth", "em"],
+        "mountPoints": ["/", "/home", "/boot"]
     },
     "ignore": {
         "cpu.busy": true,

--- a/funcs/dfstat.go
+++ b/funcs/dfstat.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+	"github.com/open-falcon/agent/g"
 	"github.com/open-falcon/common/model"
 	"github.com/toolkits/nux"
 	"log"
@@ -15,12 +16,22 @@ func DeviceMetrics() (L []*model.MetricValue) {
 		return
 	}
 
+	myMountPoints := make(map[string]bool)
+	for _, mp := range g.Config().Collector.MountPoints {
+		myMountPoints[mp] = true
+	}
+
 	var diskTotal uint64 = 0
 	var diskUsed uint64 = 0
 
 	for idx := range mountPoints {
+		fsSpec, fsFile, fsVfstype := mountPoints[idx][0], mountPoints[idx][1], mountPoints[idx][2]
+		if _, ok := myMountPoints[fsFile]; !ok {
+			continue
+		}
+
 		var du *nux.DeviceUsage
-		du, err = nux.BuildDeviceUsage(mountPoints[idx][0], mountPoints[idx][1], mountPoints[idx][2])
+		du, err = nux.BuildDeviceUsage(fsSpec, fsFile, fsVfstype)
 		if err != nil {
 			log.Println(err)
 			continue

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -38,6 +38,7 @@ type HttpConfig struct {
 
 type CollectorConfig struct {
 	IfacePrefix []string `json:"ifacePrefix"`
+	MountPoints []string `json:"mountPoints"`
 }
 
 type GlobalConfig struct {


### PR DESCRIPTION
有的操作系统可能挂载了很多文件系统，而这些文件系统的指标可能我们并不关心。为了避免过多的冗余数据，默认只采集["/", "/boot", "/home"]分区（如果有的话）的指标。