### PR TITLE
df指标支持指定采集的分区

### DIFF
--- a/cfg.example.json
+++ b/cfg.example.json
@@ -29,7 +29,8 @@
         "backdoor": false
     },
     "collector": {
-        "ifacePrefix": ["eth", "em"]
+        "ifacePrefix": ["eth", "em"],
+        "mountPoints": ["/", "/home", "/boot"]
     },
     "ignore": {
         "cpu.busy": true,

--- a/funcs/dfstat.go
+++ b/funcs/dfstat.go
@@ -16,9 +16,13 @@ func DeviceMetrics() (L []*model.MetricValue) {
 		return
 	}
 
-	myMountPoints := make(map[string]bool)
-	for _, mp := range g.Config().Collector.MountPoints {
-		myMountPoints[mp] = true
+	var myMountPoints map[string]bool = nil
+
+	if len(g.Config().Collector.MountPoints) > 0 {
+		myMountPoints = make(map[string]bool)
+		for _, mp := range g.Config().Collector.MountPoints {
+			myMountPoints[mp] = true
+		}
 	}
 
 	var diskTotal uint64 = 0
@@ -26,8 +30,11 @@ func DeviceMetrics() (L []*model.MetricValue) {
 
 	for idx := range mountPoints {
 		fsSpec, fsFile, fsVfstype := mountPoints[idx][0], mountPoints[idx][1], mountPoints[idx][2]
-		if _, ok := myMountPoints[fsFile]; !ok {
-			continue
+
+		if myMountPoints != nil {
+			if _, ok := myMountPoints[fsFile]; !ok {
+				continue
+			}
 		}
 
 		var du *nux.DeviceUsage

--- a/funcs/dfstat.go
+++ b/funcs/dfstat.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+	"github.com/open-falcon/agent/g"
 	"github.com/open-falcon/common/model"
 	"github.com/toolkits/nux"
 	"log"
@@ -15,12 +16,22 @@ func DeviceMetrics() (L []*model.MetricValue) {
 		return
 	}
 
+	myMountPoints := make(map[string]bool)
+	for _, mp := range g.Config().Collector.MountPoints {
+		myMountPoints[mp] = true
+	}
+
 	var diskTotal uint64 = 0
 	var diskUsed uint64 = 0
 
 	for idx := range mountPoints {
+		fsSpec, fsFile, fsVfstype := mountPoints[idx][0], mountPoints[idx][1], mountPoints[idx][2]
+		if _, ok := myMountPoints[fsFile]; !ok {
+			continue
+		}
+
 		var du *nux.DeviceUsage
-		du, err = nux.BuildDeviceUsage(mountPoints[idx][0], mountPoints[idx][1], mountPoints[idx][2])
+		du, err = nux.BuildDeviceUsage(fsSpec, fsFile, fsVfstype)
 		if err != nil {
 			log.Println(err)
 			continue

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -38,6 +38,7 @@ type HttpConfig struct {
 
 type CollectorConfig struct {
 	IfacePrefix []string `json:"ifacePrefix"`
+	MountPoints []string `json:"mountPoints"`
 }
 
 type GlobalConfig struct {

--- a/g/const.go
+++ b/g/const.go
@@ -10,8 +10,9 @@ import (
 // 5.0.0: 支持通过配置控制是否开启/run接口；收集udp流量数据；du某个目录的大小
 // 5.1.0: 同步插件的时候不再使用checksum机制
 // 5.1.1: 修复往多个transfer发送数据的时候crash的问题
+// 5.1.2: 支持设置df指标的分区列表
 const (
-	VERSION          = "5.1.1"
+	VERSION          = "5.1.2"
 	COLLECT_INTERVAL = time.Second
 	URL_CHECK_HEALTH = "url.check.health"
 	NET_PORT_LISTEN  = "net.port.listen"


### PR DESCRIPTION
默认采集所有分区指标，如果指定了采集分区，那么只采集指定分区指标。
配置示例：
```json
{
    "collector": {
        "ifacePrefix": ["eth", "em"],
        "mountPoints": ["/", "/home", "/boot"]
    }
}
```