### PR TITLE
fix proc_num monitor

### DIFF
--- a/cron/builtin.go
+++ b/cron/builtin.go
@@ -27,7 +27,7 @@ func syncBuiltinMetrics() {
 
 		var ports = []int64{}
 		var paths = []string{}
-		var procs = make(map[string]map[int]string)
+		var procs = make(map[string]*g.CacheProc)
 		var urls = make(map[string]string)
 
 		hostname, err := g.Hostname()
@@ -108,24 +108,21 @@ func syncBuiltinMetrics() {
 			if metric.Metric == g.PROC_NUM {
 				arr := strings.Split(metric.Tags, ",")
 
-				tmpMap := make(map[int]string)
+				proc := g.GetProc(metric.Tags)
 
 				for i := 0; i < len(arr); i++ {
 					if strings.HasPrefix(arr[i], "name=") {
-						tmpMap[1] = strings.TrimSpace(arr[i][5:])
+						proc.Name = strings.TrimSpace(arr[i][5:])
 					} else if strings.HasPrefix(arr[i], "cmdline=") {
-						tmpMap[2] = strings.TrimSpace(arr[i][8:])
+						proc.Cmdline = strings.TrimSpace(arr[i][8:])
 					}
 				}
-
-				procs[metric.Tags] = tmpMap
+				procs[metric.Tags] = proc
 			}
 		}
-
 		g.SetReportUrls(urls)
 		g.SetReportPorts(ports)
 		g.SetReportProcs(procs)
 		g.SetDuPaths(paths)
-
 	}
 }

--- a/funcs/procs.go
+++ b/funcs/procs.go
@@ -5,7 +5,6 @@ import (
 	"github.com/open-falcon/common/model"
 	"github.com/toolkits/nux"
 	"log"
-	"strings"
 )
 
 func ProcMetrics() (L []*model.MetricValue) {
@@ -24,33 +23,60 @@ func ProcMetrics() (L []*model.MetricValue) {
 
 	pslen := len(ps)
 
-	for tags, m := range reportProcs {
+	for tags, curProc := range reportProcs {
 		cnt := 0
+		pids := map[int]struct{}{}
 		for i := 0; i < pslen; i++ {
-			if is_a(ps[i], m) {
+			if is_a(ps[i], curProc) {
 				cnt++
+				pids[ps[i].Pid] = struct{}{}
 			}
 		}
-
+		if cnt > 0 && is_restart_proc(pids, curProc) {
+			//此进程发生了重启,将进程数置为0
+			cnt = 0
+		}
 		L = append(L, GaugeValue(g.PROC_NUM, cnt, tags))
 	}
-
 	return
 }
 
-func is_a(p *nux.Proc, m map[int]string) bool {
-	// only one kv pair
-	for key, val := range m {
-		if key == 1 {
-			// name
-			if val != p.Name {
-				return false
-			}
-		} else if key == 2 {
-			// cmdline
-			if !strings.Contains(p.Cmdline, val) {
-				return false
-			}
+func is_restart_proc(pids map[int]struct{}, curProc *g.CacheProc) bool {
+	if len(curProc.Pids) != len(curProc.Pids) {
+		return true
+	}
+	if len(curProc.Pids) == 1 {
+		if _, ok := curProc.Pids[-1]; ok {
+			//此进程是新加的进程监控,无需对比两次采集的进程号
+			curProc.Pids = pids
+			return false
+		}
+	}
+	flag := false
+	for pid, _ := range pids {
+		if _, ok := curProc.Pids[pid]; !ok {
+			//由tag name、cmdline标识的同一个进程在两次采集的过程中发生了重启
+			flag = true
+			break
+		}
+	}
+	curProc.Pids = pids
+	return flag
+}
+
+func is_a(p *nux.Proc, curProc *g.CacheProc) bool {
+	// name
+	if len(curProc.Name) > 0 {
+		//进程监控设置了name tag
+		if p.Name != curProc.Name {
+			return false
+		}
+	}
+	// cmdline
+	if len(curProc.Cmdline) > 0 {
+		//进程监控设置了cmdline tag
+		if p.Cmdline != curProc.Cmdline {
+			return false
 		}
 	}
 	return true

--- a/funcs/procs.go
+++ b/funcs/procs.go
@@ -23,16 +23,16 @@ func ProcMetrics() (L []*model.MetricValue) {
 
 	pslen := len(ps)
 
-	for tags, curProc := range reportProcs {
+	for tags, preProc := range reportProcs {
 		cnt := 0
 		pids := map[int]struct{}{}
 		for i := 0; i < pslen; i++ {
-			if is_a(ps[i], curProc) {
+			if is_a(ps[i], preProc) {
 				cnt++
 				pids[ps[i].Pid] = struct{}{}
 			}
 		}
-		if cnt > 0 && is_restart_proc(pids, curProc) {
+		if cnt > 0 && is_restart_proc(pids, preProc) {
 			//此进程发生了重启,将进程数置为0
 			cnt = 0
 		}
@@ -41,41 +41,42 @@ func ProcMetrics() (L []*model.MetricValue) {
 	return
 }
 
-func is_restart_proc(pids map[int]struct{}, curProc *g.CacheProc) bool {
-	if len(curProc.Pids) != len(curProc.Pids) {
+func is_restart_proc(pids map[int]struct{}, preProc *g.CacheProc) bool {
+	if len(pids) != len(preProc.Pids) {
+		//进程数目前后不一致,则认为发生重启
 		return true
 	}
-	if len(curProc.Pids) == 1 {
-		if _, ok := curProc.Pids[-1]; ok {
+	if len(preProc.Pids) == 1 {
+		if _, ok := preProc.Pids[-1]; ok {
 			//此进程是新加的进程监控,无需对比两次采集的进程号
-			curProc.Pids = pids
+			preProc.Pids = pids
 			return false
 		}
 	}
 	flag := false
 	for pid, _ := range pids {
-		if _, ok := curProc.Pids[pid]; !ok {
+		if _, ok := preProc.Pids[pid]; !ok {
 			//由tag name、cmdline标识的同一个进程在两次采集的过程中发生了重启
 			flag = true
 			break
 		}
 	}
-	curProc.Pids = pids
+	preProc.Pids = pids
 	return flag
 }
 
-func is_a(p *nux.Proc, curProc *g.CacheProc) bool {
+func is_a(p *nux.Proc, preProc *g.CacheProc) bool {
 	// name
-	if len(curProc.Name) > 0 {
+	if len(preProc.Name) > 0 {
 		//进程监控设置了name tag
-		if p.Name != curProc.Name {
+		if p.Name != preProc.Name {
 			return false
 		}
 	}
 	// cmdline
-	if len(curProc.Cmdline) > 0 {
+	if len(preProc.Cmdline) > 0 {
 		//进程监控设置了cmdline tag
-		if p.Cmdline != curProc.Cmdline {
+		if p.Cmdline != preProc.Cmdline {
 			return false
 		}
 	}

--- a/g/var.go
+++ b/g/var.go
@@ -1,14 +1,14 @@
 package g
 
 import (
+	"github.com/open-falcon/common/model"
+	"github.com/toolkits/slice"
 	"log"
+	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
-        "net"
-	"github.com/open-falcon/common/model"
-	"github.com/toolkits/slice"
 )
 
 var Root string
@@ -24,15 +24,15 @@ func InitRootDir() {
 var LocalIp string
 
 func InitLocalIp() {
-        if Config().Heartbeat.Enabled {
-		conn, err := net.DialTimeout("tcp",Config().Heartbeat.Addr,time.Second*10)
+	if Config().Heartbeat.Enabled {
+		conn, err := net.DialTimeout("tcp", Config().Heartbeat.Addr, time.Second*10)
 		if err != nil {
 			log.Println("get local addr failed !")
-		}else{
-			LocalIp = strings.Split(conn.LocalAddr().String(),":")[0]
+		} else {
+			LocalIp = strings.Split(conn.LocalAddr().String(), ":")[0]
 			conn.Close()
 		}
-	}else{
+	} else {
 		log.Println("hearbeat is not enabled, can't get localip")
 	}
 }
@@ -120,21 +120,39 @@ func SetDuPaths(paths []string) {
 	duPaths = paths
 }
 
+type CacheProc struct {
+	Pids    map[int]struct{}
+	Name    string
+	Cmdline string
+}
+
 var (
 	// tags => {1=>name, 2=>cmdline}
 	// e.g. 'name=falcon-agent'=>{1=>falcon-agent}
 	// e.g. 'cmdline=xx'=>{2=>xx}
-	reportProcs     map[string]map[int]string
+	reportProcs     map[string]*CacheProc
 	reportProcsLock = new(sync.RWMutex)
 )
 
-func ReportProcs() map[string]map[int]string {
+func GetProc(tag string) *CacheProc {
+	reportProcsLock.RLock()
+	defer reportProcsLock.RUnlock()
+	if proc, ok := reportProcs[tag]; ok {
+		return proc
+	}
+	pids := map[int]struct{}{
+		-1: struct{}{},
+	}
+	return &CacheProc{Pids: pids}
+}
+
+func ReportProcs() map[string]*CacheProc {
 	reportProcsLock.RLock()
 	defer reportProcsLock.RUnlock()
 	return reportProcs
 }
 
-func SetReportProcs(procs map[string]map[int]string) {
+func SetReportProcs(procs map[string]*CacheProc) {
 	reportProcsLock.Lock()
 	defer reportProcsLock.Unlock()
 	reportProcs = procs


### PR DESCRIPTION
###现在的情况
根据配置的cmd和cmdline 周期性扫描/proc下符合条件的进程, 当/proc下有符合条件的进程时，则proc_num数目大于0,反正则等于0. 

###问题
考虑这种情况下的程序，此程序存在缓慢的内存泄漏,持续很长时间可能由于oom被干掉，同时此程序由supervisor等进程管理工具自动拉起,如果整个挂掉到被拉起的状态刚好在agent扫描/proc的周期中, 则还是会认为此程序是正常的(实际上发生了异常重启),使得这种隐蔽问题被发现的周期大大延长.进程端口监控同样有这种问题. 