### PR TITLE
fix agent stoped kill error pid

### DIFF
--- a/control
+++ b/control
@@ -49,9 +49,15 @@ function start() {
 
 function stop() {
     pid=`cat $pidfile`
-    kill $pid
-    rm -f $pidfile
-    echo "$app stoped..."
+    pid1=`ps -ef | grep "falcon-agent -c cfg.json" | grep -v grep| awk '{print $2}'`
+    if [ $pid = $pid1 ]; then 
+        kill $pid
+        rm -f $pidfile
+        echo "$app stoped success..."
+    else
+        echo "stop fail ..."
+        exit 1
+    fi 
 }
 
 function restart() {

--- a/control
+++ b/control
@@ -48,15 +48,14 @@ function start() {
 }
 
 function stop() {
-    pid=`cat $pidfile`
-    pid1=`ps -ef | grep "falcon-agent -c cfg.json" | grep -v grep| awk '{print $2}'`
-    if [ $pid = $pid1 ]; then 
-        kill $pid
+    pid=`ps -ef | grep "falcon-agent -c cfg.json" | grep -v grep| awk '{print $2}'`
+    kill $pid
+    pid=`ps -ef | grep "falcon-agent -c cfg.json" | grep -v grep| awk '{print $2}'| wc -l`
+    if [ $pid = 0 ]; then
         rm -f $pidfile
         echo "$app stoped success..."
-    else
-        echo "stop fail ..."
-        exit 1
+    else 
+       echo "$app stoped fail..."
     fi 
 }
 


### PR DESCRIPTION
falcon-agent进程被手动kill掉进程pid文件没有被清理时， 下次如果./control restart 会先kill掉错误的进程。